### PR TITLE
Add smooth scroll on homepage arrow

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -34,10 +34,10 @@ import IconPhoto from '../assets/jorgetutor-square.jpg';
             Over 15 years in the trenches, leading complex online projects.
             </p>
         </div>
-        <div class="mt-8 animate-bounce">
+        <a href="#main" aria-label="Scroll to main content" class="mt-8 animate-bounce block">
             <svg class="w-8 h-8 text-[var(--accent)]" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M12.5303 16.2803C12.2374 16.5732 11.7626 16.5732 11.4697 16.2803L3.96967 8.78033C3.67678 8.48744 3.67678 8.01256 3.96967 7.71967C4.26256 7.42678 4.73744 7.42678 5.03033 7.71967L12 14.6893L18.9697 7.71967C19.2626 7.42678 19.7374 7.42678 20.0303 7.71967C20.3232 8.01256 20.3232 8.48744 20.0303 8.78033L12.5303 16.2803Z" />
             </svg>
-        </div>
+        </a>
     </section>
   )}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,9 +15,9 @@ const { frontmatter } = Astro.props;
 	</head>
 	<body>
 		<Header />
-		<main>
-			<slot />
-		</main>
+                <main id="main">
+                        <slot />
+                </main>
 		<Footer />
 	</body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -42,10 +42,14 @@
     font-size: 20px;
     line-height: 1.7;
   }
+  html {
+    scroll-behavior: smooth;
+  }
   main {
     max-width: 1024px;
     margin: auto;
     padding: 1em 1em;
+    scroll-margin-top: 3em;
   }
   h1,
   h2,


### PR DESCRIPTION
## Summary
- link hero arrow to `#main` section
- allow html smooth-scrolling
- add an anchor for `<main>` so the arrow works
- offset anchor scrolling for fixed header

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853faa9bea4832eb188f72df159df2c